### PR TITLE
remove thrift results columns assert

### DIFF
--- a/python/pyhive/hive.py
+++ b/python/pyhive/hive.py
@@ -568,9 +568,10 @@ class Cursor(common.DBAPICursor):
                 response = self._connection.client.FetchResults(req)
                 _check_status(response)
                 assert not response.results.rows, 'expected data in columnar format'
-                assert len(response.results.columns) == 1, response.results.columns
-                new_logs = _unwrap_column(response.results.columns[0])
-                logs += new_logs
+                new_logs = ''
+                if response.results.columns:
+                    new_logs = _unwrap_column(response.results.columns[0])
+                    logs += new_logs
 
                 if not new_logs:
                     break


### PR DESCRIPTION

affected version pypi pyhive package 0.6.5 , 0.7.0
### Why are the changes needed?

using I using pyhive connect to kyuubi 1.7/1.10.0 and submit SQL to Spark3.2/3.5 in async 
some times when I fetch_logs thrift results response columns could be None 
assert get length may cause TypeError: object of type 'NoneType' has no len()

traceback is

>   File "/root/app/dataverse/operator/sqltask.py", line 225, in execute_single_hql
    for message in cursor.fetch_logs():
  File "/usr/local/lib/python3.10/dist-packages/pyhive/hive.py", line 537, in fetch_logs
    assert len(response.results.columns) == 1, response.results.columns
TypeError: object of type 'NoneType' has no len()

### How was this patch tested?
we deploy test env using special build kyuubi server, ensure FetchResults.results.columns returns null
after this patch fetch_logs() will not cause any Exception
and then we tested in normal release version of kyuubi too , fetch_logs() works fine
-> finally we tested in production environment for more than 1000 task instance


### Was this patch authored or co-authored using generative AI tooling?
No

